### PR TITLE
Response body respond to each for 1.9

### DIFF
--- a/lib/rack/throttle/limiter.rb
+++ b/lib/rack/throttle/limiter.rb
@@ -188,7 +188,7 @@ module Rack; module Throttle
     # @return [Array(Integer, Hash, #each)]
     def http_error(code, message = nil, headers = {})
       [code, {'Content-Type' => 'text/plain; charset=utf-8'}.merge(headers),
-        http_status(code) + (message.nil? ? "\n" : " (#{message})\n")]
+        [http_status(code), (message.nil? ? "\n" : " (#{message})\n")]]
     end
 
     ##


### PR DESCRIPTION
Per the spec, "The Body itself should not be an instance of String, as this will break in Ruby 1.9." This patches Rack::Throttle::Limiter#http_error to return an array of strings.
