### PR TITLE
Updated Rack::Throttle::Limiter#http_error to return HTTP body as an array

### DIFF
--- a/lib/rack/throttle/limiter.rb
+++ b/lib/rack/throttle/limiter.rb
@@ -187,8 +187,10 @@ module Rack; module Throttle
     # @param  [Hash{String => String}] headers
     # @return [Array(Integer, Hash, #each)]
     def http_error(code, message = nil, headers = {})
-      [code, {'Content-Type' => 'text/plain; charset=utf-8'}.merge(headers),
-        http_status(code) + (message.nil? ? "\n" : " (#{message})\n")]
+      [ code,
+        { 'Content-Type' => 'text/plain; charset=utf-8' }.merge(headers),
+        Array( http_status(code) + (message.nil? ? "\n" : " (#{message})\n") )
+      ]
     end
 
     ##


### PR DESCRIPTION
On Ruby 1.9.3 and Rails 3.2.x, the server was returning empty response, due to:

```
!! Unexpected error while processing request: undefined method `each' for "403 Forbidden (Rate Limit Exceeded)\n":String
```

See http://rack.rubyforge.org/doc/files/SPEC.html, "The Body itself should not be an instance of String, as this will break in Ruby 1.9."
