### PR TITLE
Autoload Second module

### DIFF
--- a/lib/rack/throttle.rb
+++ b/lib/rack/throttle.rb
@@ -8,6 +8,7 @@ module Rack
     autoload :Daily,      ::File.expand_path(::File.dirname(__FILE__)) + '/throttle/daily'
     autoload :Hourly,     ::File.expand_path(::File.dirname(__FILE__)) + '/throttle/hourly'
     autoload :Minute,     ::File.expand_path(::File.dirname(__FILE__)) + '/throttle/minute'
+    autoload :Second,     ::File.expand_path(::File.dirname(__FILE__)) + '/throttle/second'
     autoload :VERSION,    ::File.expand_path(::File.dirname(__FILE__)) + '/throttle/version'
   end
 end


### PR DESCRIPTION
Using the following in a Rails 5 app:

```ruby
    config.middleware.use Rack::Throttle::Second, max: 2
```

produces the following error:

```
`<class:Application>': uninitialized constant Rack::Throttle::Second (NameError)
```