### PR TITLE
Add lib directory to load path

### DIFF
--- a/rack-throttle.gemspec
+++ b/rack-throttle.gemspec
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby -rubygems
 # -*- encoding: utf-8 -*-
 
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 Gem::Specification.new do |gem|
   gem.version            = File.read('VERSION').chomp
   gem.date               = File.mtime('VERSION').strftime('%Y-%m-%d')


### PR DESCRIPTION
These lines are standard for the default bundler output when creating a
new gem.

When I was having trouble getting the `Second` module loaded, my
instinct said to try:

```
require 'rack/throttle/second'
```

That didn't work because the `/lib` hadn't been added to the load path.
I don't know of any downside to doing so.