### PR TITLE
Add bundler as a dev dependency 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,19 @@
 PATH
   remote: .
   specs:
-    rack-throttle (0.3.0)
+    rack-throttle (0.4.1)
+      bundler (>= 1.0.0)
       rack (>= 1.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    rack (1.2.2)
+    rack (2.0.1)
     rack-test (0.5.3)
       rack (>= 1.0)
     rspec (1.3.0)
     timecop (0.3.4)
-    yard (0.6.8)
+    yard (0.9.5)
 
 PLATFORMS
   ruby
@@ -23,3 +24,6 @@ DEPENDENCIES
   rspec (= 1.3.0)
   timecop (= 0.3.4)
   yard (>= 0.5.5)
+
+BUNDLED WITH
+   1.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     rack (2.0.1)
     rack-test (0.5.3)
       rack (>= 1.0)
+    rake (11.2.2)
     rspec (1.3.0)
     timecop (0.3.4)
     yard (0.9.5)
@@ -21,6 +22,7 @@ PLATFORMS
 DEPENDENCIES
   rack-test (= 0.5.3)
   rack-throttle!
+  rake
   rspec (= 1.3.0)
   timecop (= 0.3.4)
   yard (>= 0.5.5)

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,4 @@ begin
 rescue LoadError => e
 end
 require 'rack/throttle'
+require 'bundler/gem_tasks'

--- a/rack-throttle.gemspec
+++ b/rack-throttle.gemspec
@@ -29,10 +29,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version      = '>= 1.8.2'
   gem.requirements               = []
+  gem.add_runtime_dependency     'bundler',   '>= 1.0.0'
+  gem.add_runtime_dependency     'rack',      '>= 1.0.0'
   gem.add_development_dependency 'rack-test', '0.5.3'
   gem.add_development_dependency 'rspec',     '1.3.0'
-  gem.add_development_dependency 'yard' ,     '>= 0.5.5'
   gem.add_development_dependency 'timecop',   '0.3.4'
-  gem.add_runtime_dependency     'rack',      '>= 1.0.0'
+  gem.add_development_dependency 'yard' ,     '>= 0.5.5'
   gem.post_install_message       = nil
 end

--- a/rack-throttle.gemspec
+++ b/rack-throttle.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'bundler',   '>= 1.0.0'
   gem.add_runtime_dependency     'rack',      '>= 1.0.0'
   gem.add_development_dependency 'rack-test', '0.5.3'
+  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec',     '1.3.0'
   gem.add_development_dependency 'timecop',   '0.3.4'
   gem.add_development_dependency 'yard' ,     '>= 0.5.5'


### PR DESCRIPTION
This will add bundler & rake as a development for use of the `rake release` command.

This also updates our Gemfile.lock for prep of a release.