### PR TITLE
Add minute directive in second interval

### DIFF
--- a/lib/rack/throttle/second.rb
+++ b/lib/rack/throttle/second.rb
@@ -36,7 +36,7 @@ module Rack; module Throttle
     # @param  [Rack::Request] request
     # @return [String]
     def cache_key(request)
-      [super, Time.now.strftime('%Y-%m-%dT%H:%S')].join(':')
+      [super, Time.now.strftime('%Y-%m-%dT%H:%M:%S')].join(':')
     end
   end
 end; end

--- a/spec/daily_spec.rb
+++ b/spec/daily_spec.rb
@@ -22,13 +22,15 @@ describe Rack::Throttle::Daily do
     expect(last_response.body).to show_throttled_response
   end
 
-  it "should not count last days requests against today" do
-    Timecop.freeze(DateTime.now - 1) do
-      4.times { get "/foo" }
-      expect(last_response.body).to show_throttled_response
-    end
+  [:day_ago].each do |time|
+    it "should not count the requests from a #{time.to_s.split('_').join(' ')} against this second" do
+      Timecop.freeze(1.send(time)) do
+        4.times { get "/foo" }
+        expect(last_response.body).to show_throttled_response
+      end
 
-    get "/foo"
-    expect(last_response.body).to show_allowed_response
+      get "/foo"
+      expect(last_response.body).to show_allowed_response
+    end
   end
 end

--- a/spec/hourly_spec.rb
+++ b/spec/hourly_spec.rb
@@ -22,13 +22,15 @@ describe Rack::Throttle::Hourly do
     expect(last_response.body).to show_throttled_response
   end
 
-  it "should not count last hours requests against today" do
-    Timecop.freeze(DateTime.now - 1/24.0) do
-      4.times { get "/foo" }
-      expect(last_response.body).to show_throttled_response
-    end
+  [:hour_ago, :day_ago].each do |time|
+    it "should not count the requests from a #{time.to_s.split('_').join(' ')} against this hour" do
+      Timecop.freeze(1.send(time)) do
+        4.times { get "/foo" }
+        expect(last_response.body).to show_throttled_response
+      end
 
-    get "/foo"
-    expect(last_response.body).to show_allowed_response
+      get "/foo"
+      expect(last_response.body).to show_allowed_response
+    end
   end
 end

--- a/spec/minute_spec.rb
+++ b/spec/minute_spec.rb
@@ -22,13 +22,15 @@ describe Rack::Throttle::Minute do
     expect(last_response.body).to show_throttled_response
   end
 
-  it "should not count last minutes requests against today" do
-    Timecop.freeze(DateTime.now - 1/24.0/60.0) do
-      4.times { get "/foo" }
-      expect(last_response.body).to show_throttled_response
-    end
+  [:minute_ago, :hour_ago, :day_ago].each do |time|
+    it "should not count the requests from a #{time.to_s.split('_').join(' ')} against this minute" do
+      Timecop.freeze(1.send(time)) do
+        4.times { get "/foo" }
+        expect(last_response.body).to show_throttled_response
+      end
 
-    get "/foo"
-    expect(last_response.body).to show_allowed_response
+      get "/foo"
+      expect(last_response.body).to show_allowed_response
+    end
   end
 end

--- a/spec/second_spec.rb
+++ b/spec/second_spec.rb
@@ -22,13 +22,15 @@ describe Rack::Throttle::Second do
     expect(last_response.body).to show_throttled_response
   end
 
-  it "should not count last seconds requests against today" do
-    Timecop.freeze(DateTime.now - 1/24.0/60.0/60.0) do
-      4.times { get "/foo" }
-      expect(last_response.body).to show_throttled_response
-    end
+  [:second_ago, :minute_ago, :hour_ago, :day_ago].each do |time|
+    it "should not count the requests from a #{time.to_s.split('_').join(' ')} against this second" do
+      Timecop.freeze(1.send(time)) do
+        4.times { get "/foo" }
+        expect(last_response.body).to show_throttled_response
+      end
 
-    get "/foo"
-    expect(last_response.body).to show_allowed_response
+      get "/foo"
+      expect(last_response.body).to show_allowed_response
+    end
   end
 end

--- a/spec/support/time_intervals.rb
+++ b/spec/support/time_intervals.rb
@@ -1,0 +1,21 @@
+class Fixnum
+  def seconds_ago
+    Time.now - self
+  end
+  alias_method :second_ago, :seconds_ago
+
+  def minutes_ago
+    Time.now - (self * 60)
+  end
+  alias_method :minute_ago, :minutes_ago
+
+  def hours_ago
+    Time.now - (self * 60 * 60)
+  end
+  alias_method :hour_ago, :hours_ago
+
+  def days_ago
+    Time.now - (self * 60 * 60 * 24)
+  end
+  alias_method :day_ago, :days_ago
+end


### PR DESCRIPTION
This PR fixes #29 

It adds the missing minute directive in the second interval's `cache_key`

It also adds proper testing around second-day interval specs to make sure this doesn't happen again.