### PR TITLE
Add request to max_per_window method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-throttle (0.4.1)
+    rack-throttle (0.4.2)
       bundler (>= 1.0.0)
       rack (>= 1.0.0)
 
@@ -39,4 +39,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.14.3

--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ significantly more complex than what we've provided for, you can also define
 entirely new kinds of throttling strategies by subclassing the
 `Rack::Throttle::Limiter` base class directly.
 
+### Example
+
+Customize the `max_per_second` to be different depending on the request's method.
+
+```
+class Rack::Throttle::RequestMethod < Rack::Throttle::Second
+
+  def max_per_second(request = nil)
+    return (options[:max_per_second] || options[:max] || 1) unless request
+    if request.request_method == "POST"
+      4
+    else
+      10
+    end
+  end
+  alias_method :max_per_window, :max_per_second
+
+end
+```
+
+
 HTTP Client Identification
 --------------------------
 

--- a/lib/rack/throttle/daily.rb
+++ b/lib/rack/throttle/daily.rb
@@ -26,7 +26,7 @@ module Rack; module Throttle
     end
 
     ##
-    def max_per_day
+    def max_per_day(request = nil)
       @max_per_hour ||= options[:max_per_day] || options[:max] || 86_400
     end
 

--- a/lib/rack/throttle/hourly.rb
+++ b/lib/rack/throttle/hourly.rb
@@ -26,7 +26,7 @@ module Rack; module Throttle
     end
 
     ##
-    def max_per_hour
+    def max_per_hour(request = nil)
       @max_per_hour ||= options[:max_per_hour] || options[:max] || 3_600
     end
 

--- a/lib/rack/throttle/minute.rb
+++ b/lib/rack/throttle/minute.rb
@@ -25,7 +25,7 @@ module Rack; module Throttle
     end
 
     ##
-    def max_per_minute
+    def max_per_minute(request = nil)
       @max_per_minute ||= options[:max_per_minute] || options[:max] || 60
     end
 

--- a/lib/rack/throttle/second.rb
+++ b/lib/rack/throttle/second.rb
@@ -24,7 +24,7 @@ module Rack; module Throttle
     end
 
     ##
-    def max_per_second
+    def max_per_second(request = nil)
       @max_per_second ||= options[:max_per_second] || options[:max] || 1
     end
 

--- a/lib/rack/throttle/time_window.rb
+++ b/lib/rack/throttle/time_window.rb
@@ -10,7 +10,7 @@ module Rack; module Throttle
     def allowed?(request)
       return true if whitelisted?(request)
       count = cache_get(key = cache_key(request)).to_i + 1 rescue 1
-      allowed = count <= max_per_window.to_i
+      allowed = count <= max_per_window(request).to_i
       begin
         cache_set(key, count)
         allowed

--- a/spec/request_method_spec.rb
+++ b/spec/request_method_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+class Rack::Throttle::RequestMethod < Rack::Throttle::Second
+
+  def max_per_second(request = nil)
+    return (options[:max_per_second] || options[:max] || 1) unless request
+    if request.request_method == "POST"
+      4
+    else
+      10
+    end
+  end
+  alias_method :max_per_window, :max_per_second
+
+end
+
+describe Rack::Throttle::RequestMethod do
+  include Rack::Test::Methods
+
+  include_context 'mock app'
+
+  let(:app) { described_class.new(target_app) }
+
+  it "should be allowed if not seen this second" do
+    get "/foo"
+    expect(last_response.body).to show_allowed_response
+  end
+
+  it "should be allowed if seen fewer than the max allowed per second" do
+    4.times { get "/foo" }
+    expect(last_response.body).to show_allowed_response
+  end
+
+  it "should not be allowed if seen more times than the max allowed per second" do
+    20.times { get "/foo" }
+    expect(last_response.body).to show_throttled_response
+  end
+  
+  it "should not be allowed if seen more times than the max allowed per second" do
+    10.times { post "/foo" }
+    expect(last_response.body).to show_throttled_response
+  end
+
+  [:second_ago, :minute_ago, :hour_ago, :day_ago].each do |time|
+    it "should not count the requests from a #{time.to_s.split('_').join(' ')} against this second" do
+      Timecop.freeze(1.send(time)) do
+        20.times { get "/foo" }
+        expect(last_response.body).to show_throttled_response
+      end
+
+      get "/foo"
+      expect(last_response.body).to show_allowed_response
+    end
+  end
+end


### PR DESCRIPTION
This would enable to override the max_per_\<period\> method with something request specific.

E.g. check request.request_method to allow 100 GET but only 10 POST requests. (see tests)