### PR TITLE
Fix option name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Rules are checked in this order:
 It is possible to set the time window for this strategy to: `:second` (default), `:minute`, `:hour` or `:day`, to change the check interval to these windows.
 
 ```ruby
-use Rack::Throttle::Rules, limits: limits, time_window: :minute
+use Rack::Throttle::Rules, rules: rules, time_window: :minute
 ```
 
 


### PR DESCRIPTION
There appear to be a discrepancy between the two code examples for `Rack::Throttle::Rules`: the first one uses `rules` and the second `limits`. I did not find any option named `limit` in `Rack::Throttle::Rules`, so I updated the README.

